### PR TITLE
Add minimal chess reinforcement learning framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# Codex-Repo
+# Chess AI Module
+
+This repository contains a minimal chess reinforcement learning setup based on
+`python-chess` and PyTorch. The code can train an agent through self-play and
+lets you play against it from the command line.
+
+## Installation
+
+1. Ensure Python 3.11+ is available.
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+The requirements file installs a CPU only build of PyTorch and `python-chess`.
+
+## Training
+
+Use `train.py` to run self‑play training. The script saves a checkpoint after
+training.
+
+```bash
+python -m chess_ai.train --episodes 100 --checkpoint agent.pth
+```
+
+Arguments:
+
+- `--episodes` – number of self-play games to run.
+- `--checkpoint` – file where the model will be saved.
+- `--load` – optional path to an existing model to continue training.
+
+## Playing Against the Agent
+
+Once trained, you can play against the agent using `play_ui.py`:
+
+```bash
+python -m chess_ai.play_ui --model agent.pth
+```
+
+The UI prints the board in ASCII. When it is your move (always White), enter
+moves in UCI notation (e.g. `e2e4`). The agent responds automatically until the
+game is finished.
+
+## File Overview
+
+- `chess_ai/chess_env.py` – thin wrapper around `python-chess` providing board
+  state and legal move handling.
+- `chess_ai/rl_agent.py` – simple value-based reinforcement learning agent
+  implemented with PyTorch.
+- `chess_ai/train.py` – command line interface to train the agent through
+  self-play.
+- `chess_ai/play_ui.py` – minimal text interface to play against the trained
+  agent.
+
+The implementation is intentionally compact and meant for experimentation rather
+than competitive play.

--- a/chess_ai/__init__.py
+++ b/chess_ai/__init__.py
@@ -1,0 +1,6 @@
+"""Chess AI package."""
+
+from .chess_env import ChessEnv
+from .rl_agent import RLAgent
+
+__all__ = ["ChessEnv", "RLAgent"]

--- a/chess_ai/chess_env.py
+++ b/chess_ai/chess_env.py
@@ -1,0 +1,52 @@
+import chess
+import numpy as np
+
+class ChessEnv:
+    """Simple wrapper around python-chess."""
+
+    def __init__(self):
+        self.board = chess.Board()
+
+    def reset(self):
+        self.board.reset()
+        return self.get_state()
+
+    def get_state(self):
+        return self.board.fen()
+
+    def legal_moves(self):
+        return [move.uci() for move in self.board.legal_moves]
+
+    def step(self, move_uci: str):
+        move = chess.Move.from_uci(move_uci)
+        if move not in self.board.legal_moves:
+            raise ValueError("Illegal move")
+        self.board.push(move)
+        done = self.board.is_game_over()
+        reward = 0.0
+        if done:
+            result = self.board.result()
+            if result == '1-0':
+                reward = 1.0
+            elif result == '0-1':
+                reward = -1.0
+        return self.get_state(), reward, done, {}
+
+    @staticmethod
+    def board_tensor(board: chess.Board) -> np.ndarray:
+        """Return board representation as (12, 8, 8) tensor."""
+        mapping = {
+            chess.PAWN: 0,
+            chess.KNIGHT: 1,
+            chess.BISHOP: 2,
+            chess.ROOK: 3,
+            chess.QUEEN: 4,
+            chess.KING: 5,
+        }
+        tensor = np.zeros((12, 8, 8), dtype=np.float32)
+        for square, piece in board.piece_map().items():
+            idx = mapping[piece.piece_type] + (0 if piece.color == chess.WHITE else 6)
+            row = chess.square_rank(square)
+            col = chess.square_file(square)
+            tensor[idx, row, col] = 1
+        return tensor

--- a/chess_ai/play_ui.py
+++ b/chess_ai/play_ui.py
@@ -1,0 +1,36 @@
+import argparse
+import chess
+
+from .chess_env import ChessEnv
+from .rl_agent import RLAgent
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Play against the trained agent")
+    parser.add_argument("--model", type=str, default="agent.pth", help="Path to trained model")
+    args = parser.parse_args()
+
+    env = ChessEnv()
+    agent = RLAgent()
+    try:
+        agent.load(args.model)
+    except FileNotFoundError:
+        print("Model not found, playing with untrained agent.")
+
+    while not env.board.is_game_over():
+        print(env.board)
+        if env.board.turn == chess.WHITE:
+            move = input("Your move (UCI): ")
+        else:
+            move = agent.choose_move(env.board, epsilon=0.0)
+            print(f"AI move: {move}")
+        try:
+            env.step(move)
+        except ValueError:
+            print("Illegal move. Try again.")
+    print(env.board)
+    print("Game over:", env.board.result())
+
+
+if __name__ == "__main__":
+    main()

--- a/chess_ai/rl_agent.py
+++ b/chess_ai/rl_agent.py
@@ -1,0 +1,100 @@
+import random
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import numpy as np
+
+from .chess_env import ChessEnv
+
+
+def _state_tensor(board):
+    return torch.from_numpy(ChessEnv.board_tensor(board))
+
+
+class ValueNetwork(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(12, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Flatten(),
+            nn.Linear(64 * 8 * 8, 128),
+            nn.ReLU(),
+            nn.Linear(128, 1),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class RLAgent:
+    def __init__(self, lr: float = 1e-3, gamma: float = 0.99, device: str | None = None):
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = ValueNetwork().to(self.device)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=lr)
+        self.gamma = gamma
+        self.memory: List[Tuple[torch.Tensor, float, torch.Tensor, bool]] = []
+        self.loss_fn = nn.MSELoss()
+
+    def predict(self, board) -> float:
+        with torch.no_grad():
+            tensor = _state_tensor(board).unsqueeze(0).to(self.device)
+            value = self.model(tensor).item()
+        return value
+
+    def choose_move(self, board, epsilon: float = 0.1) -> str:
+        moves = list(board.legal_moves)
+        if random.random() < epsilon:
+            return random.choice(moves).uci()
+        best_move = None
+        best_value = -float("inf")
+        for m in moves:
+            board.push(m)
+            v = self.predict(board)
+            board.pop()
+            if v > best_value or best_move is None:
+                best_value = v
+                best_move = m
+        return best_move.uci()
+
+    def remember(self, state, reward, next_state, done):
+        self.memory.append((state, reward, next_state, done))
+
+    def train_step(self, batch_size: int = 32):
+        if len(self.memory) < batch_size:
+            return
+        batch = random.sample(self.memory, batch_size)
+        states, rewards, next_states, dones = zip(*batch)
+        states = torch.stack(states).to(self.device)
+        next_states = torch.stack(next_states).to(self.device)
+        rewards = torch.tensor(rewards, device=self.device)
+        dones = torch.tensor(dones, dtype=torch.float32, device=self.device)
+        target = rewards + self.gamma * self.model(next_states).squeeze() * (1 - dones)
+        values = self.model(states).squeeze()
+        loss = self.loss_fn(values, target.detach())
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+    def train_self_play(self, episodes: int = 1, epsilon: float = 0.2, batch_size: int = 32):
+        env = ChessEnv()
+        for _ in range(episodes):
+            env.reset()
+            done = False
+            while not done:
+                state_tensor = _state_tensor(env.board)
+                move = self.choose_move(env.board, epsilon)
+                _, reward, done, _ = env.step(move)
+                next_tensor = _state_tensor(env.board)
+                self.remember(state_tensor, reward, next_tensor, done)
+                self.train_step(batch_size)
+
+    def save(self, path: str):
+        torch.save(self.model.state_dict(), path)
+
+    def load(self, path: str):
+        self.model.load_state_dict(torch.load(path, map_location=self.device))

--- a/chess_ai/train.py
+++ b/chess_ai/train.py
@@ -1,0 +1,21 @@
+import argparse
+
+from .rl_agent import RLAgent
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train RL chess agent")
+    parser.add_argument("--episodes", type=int, default=10, help="Number of self-play episodes")
+    parser.add_argument("--checkpoint", type=str, default="agent.pth", help="Path to save checkpoint")
+    parser.add_argument("--load", type=str, help="Optional model path to continue training")
+    args = parser.parse_args()
+
+    agent = RLAgent()
+    if args.load:
+        agent.load(args.load)
+    agent.train_self_play(args.episodes)
+    agent.save(args.checkpoint)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+python-chess
+torch==2.3.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary
- create `chess_ai` package with reinforcement-learning agent
- wrap `python-chess` board in `ChessEnv`
- implement simple self-play training and model persistence
- provide CLI training script and minimal play UI
- document installation, training and play instructions in README
- include requirements for numpy, python-chess and CPU-only PyTorch

## Testing
- `python -m py_compile chess_ai/*.py`
- `python -m chess_ai.train --episodes 1 --checkpoint temp.pth`
- `python -m chess_ai.play_ui --model temp.pth` *(fails after user input ends)*

------
https://chatgpt.com/codex/tasks/task_e_685758e17b9c8322b6bcb8fb38b6eddf