### PR TITLE
Add Pygame UI and training plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# Codex-Repo
+# Chess AI Project
+
+This project demonstrates a simple reinforcement learning agent that learns to play chess through self‑play.
+
+## Setup
+
+1. Create a Python virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Training
+
+Run the training script to let the agent learn by self-play. A Plotly HTML
+file can be generated to visualize rewards over time:
+
+```bash
+python -m chess_ai.train --episodes 1000 --checkpoint agent.pth --plot training.html
+```
+
+This will store a model checkpoint at `agent.pth`.
+
+## Play against the AI
+
+After training, you can play against the agent in the terminal or with a
+graphical interface.
+
+```bash
+python -m chess_ai.play_ui --model agent.pth
+
+```
+
+For a graphical board using Pygame (with simple animations) run:
+
+```bash
+python -m chess_ai.pygame_ui --model agent.pth
+```
+
+Moves are entered in UCI notation (e.g., `e2e4`).
+
+## Repository Structure
+
+- `chess_ai/` – Package containing the environment, agent, and scripts
+- `requirements.txt` – Project dependencies
+- `README.md` – Project overview and instructions

--- a/assets/svg/bdt.svg
+++ b/assets/svg/bdt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='black'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='white'>b</text></svg>

--- a/assets/svg/blt.svg
+++ b/assets/svg/blt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='white'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='black'>B</text></svg>

--- a/assets/svg/kdt.svg
+++ b/assets/svg/kdt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='black'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='white'>k</text></svg>

--- a/assets/svg/klt.svg
+++ b/assets/svg/klt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='white'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='black'>K</text></svg>

--- a/assets/svg/ndt.svg
+++ b/assets/svg/ndt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='black'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='white'>n</text></svg>

--- a/assets/svg/nlt.svg
+++ b/assets/svg/nlt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='white'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='black'>N</text></svg>

--- a/assets/svg/pdt.svg
+++ b/assets/svg/pdt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='black'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='white'>p</text></svg>

--- a/assets/svg/plt.svg
+++ b/assets/svg/plt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='white'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='black'>P</text></svg>

--- a/assets/svg/qdt.svg
+++ b/assets/svg/qdt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='black'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='white'>q</text></svg>

--- a/assets/svg/qlt.svg
+++ b/assets/svg/qlt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='white'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='black'>Q</text></svg>

--- a/assets/svg/rdt.svg
+++ b/assets/svg/rdt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='black'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='white'>r</text></svg>

--- a/assets/svg/rlt.svg
+++ b/assets/svg/rlt.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='45' height='45'><rect width='45' height='45' fill='white'/><text x='50%' y='50%' font-family='Arial' font-size='32' dominant-baseline='middle' text-anchor='middle' fill='black'>R</text></svg>

--- a/chess_ai/__init__.py
+++ b/chess_ai/__init__.py
@@ -1,0 +1,6 @@
+"""Simple Chess AI package."""
+
+from .chess_env import ChessEnv
+from .rl_agent import PolicyNetwork, select_move
+
+__all__ = ["ChessEnv", "PolicyNetwork", "select_move"]

--- a/chess_ai/chess_env.py
+++ b/chess_ai/chess_env.py
@@ -1,0 +1,41 @@
+import chess
+import numpy as np
+
+class ChessEnv:
+    """A minimal chess environment for self-play."""
+
+    def __init__(self):
+        self.board = chess.Board()
+
+    def reset(self):
+        self.board.reset()
+        return self._get_state()
+
+    def _get_state(self):
+        # Simple board encoding: piece values on board
+        board_state = np.zeros(64, dtype=np.int8)
+        for square in chess.SQUARES:
+            piece = self.board.piece_at(square)
+            if piece:
+                value = piece.piece_type if piece.color == chess.WHITE else -piece.piece_type
+                board_state[square] = value
+        return board_state
+
+    def step(self, move_uci):
+        move = chess.Move.from_uci(move_uci)
+        if move not in self.board.legal_moves:
+            raise ValueError("Illegal move")
+        self.board.push(move)
+        done = self.board.is_game_over()
+        reward = 0.0
+        if done:
+            result = self.board.result()
+            if result == "1-0":
+                reward = 1.0
+            elif result == "0-1":
+                reward = -1.0
+        return self._get_state(), reward, done
+
+    @property
+    def legal_moves(self):
+        return [m.uci() for m in self.board.legal_moves]

--- a/chess_ai/play_ui.py
+++ b/chess_ai/play_ui.py
@@ -1,0 +1,38 @@
+import argparse
+import chess
+from .chess_env import ChessEnv
+from .rl_agent import PolicyNetwork, select_move
+import torch
+
+
+def play(model_path: str):
+    env = ChessEnv()
+    policy = PolicyNetwork()
+    policy.load_state_dict(torch.load(model_path))
+    state = env.reset()
+    turn_white = True
+    while True:
+        if turn_white:
+            print(env.board)
+            move = input("Your move: ")
+            try:
+                state, reward, done = env.step(move)
+            except Exception as e:
+                print(e)
+                continue
+        else:
+            move = select_move(policy, state, env.legal_moves)
+            print(f"AI move: {move}")
+            state, reward, done = env.step(move)
+        if done:
+            print(env.board)
+            print("Game over:", env.board.result())
+            break
+        turn_white = not turn_white
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, required=True)
+    args = parser.parse_args()
+    play(args.model)

--- a/chess_ai/pygame_ui.py
+++ b/chess_ai/pygame_ui.py
@@ -1,0 +1,118 @@
+import argparse
+import io
+import pygame
+import cairosvg
+import torch
+import chess
+from .chess_env import ChessEnv
+from .rl_agent import PolicyNetwork, select_move
+
+SQUARE_SIZE = 60
+BOARD_SIZE = SQUARE_SIZE * 8
+
+PIECE_FILES = {
+    'P': 'plt.svg', 'N': 'nlt.svg', 'B': 'blt.svg', 'R': 'rlt.svg', 'Q': 'qlt.svg', 'K': 'klt.svg',
+    'p': 'pdt.svg', 'n': 'ndt.svg', 'b': 'bdt.svg', 'r': 'rdt.svg', 'q': 'qdt.svg', 'k': 'kdt.svg'
+}
+
+
+def load_piece_images():
+    images = {}
+    for key, fname in PIECE_FILES.items():
+        with open(f"assets/svg/{fname}", "rb") as f:
+            png_bytes = cairosvg.svg2png(file_obj=f)
+        img = pygame.image.load(io.BytesIO(png_bytes))
+        img = pygame.transform.smoothscale(img, (SQUARE_SIZE, SQUARE_SIZE))
+        images[key] = img
+    return images
+
+
+def draw_board(screen, board, images, animation=None):
+    colors = [(240, 217, 181), (181, 136, 99)]
+    for rank in range(8):
+        for file in range(8):
+            color = colors[(rank + file) % 2]
+            rect = pygame.Rect(file * SQUARE_SIZE, (7 - rank) * SQUARE_SIZE, SQUARE_SIZE, SQUARE_SIZE)
+            pygame.draw.rect(screen, color, rect)
+    for square in chess.SQUARES:
+        piece = board.piece_at(square)
+        if piece:
+            row = 7 - chess.square_rank(square)
+            col = chess.square_file(square)
+            key = piece.symbol()
+            img = images[key]
+            pos = (col * SQUARE_SIZE, row * SQUARE_SIZE)
+            if animation and animation['square'] == square:
+                pos = animation['pos']
+            screen.blit(img, pos)
+
+
+def animate_move(screen, board, images, move):
+    start = chess.square_file(move.from_square) * SQUARE_SIZE, (7 - chess.square_rank(move.from_square)) * SQUARE_SIZE
+    end = chess.square_file(move.to_square) * SQUARE_SIZE, (7 - chess.square_rank(move.to_square)) * SQUARE_SIZE
+    frames = 10
+    piece = board.piece_at(move.from_square)
+    if not piece:
+        return
+    for i in range(1, frames + 1):
+        interp = (i / frames)
+        x = start[0] + (end[0] - start[0]) * interp
+        y = start[1] + (end[1] - start[1]) * interp
+        screen.fill((0, 0, 0))
+        draw_board(screen, board, images, {'square': move.from_square, 'pos': (x, y)})
+        pygame.display.flip()
+        pygame.time.delay(30)
+
+
+def play(model_path: str):
+    pygame.init()
+    screen = pygame.display.set_mode((BOARD_SIZE, BOARD_SIZE))
+    pygame.display.set_caption("Chess AI")
+    images = load_piece_images()
+
+    env = ChessEnv()
+    policy = PolicyNetwork()
+    policy.load_state_dict(torch.load(model_path))
+    state = env.reset()
+    running = True
+    selected = None
+    turn_white = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.MOUSEBUTTONDOWN and turn_white:
+                x, y = event.pos
+                col = x // SQUARE_SIZE
+                row = 7 - (y // SQUARE_SIZE)
+                square = chess.square(col, row)
+                if selected is None:
+                    if env.board.piece_at(square) and env.board.piece_at(square).color == chess.WHITE:
+                        selected = square
+                else:
+                    move = chess.Move(selected, square)
+                    if move in env.board.legal_moves:
+                        animate_move(screen, env.board, images, move)
+                        state, reward, done = env.step(move.uci())
+                        selected = None
+                        turn_white = False
+        if not turn_white:
+            move = select_move(policy, state, env.legal_moves)
+            m = chess.Move.from_uci(move)
+            animate_move(screen, env.board, images, m)
+            state, reward, done = env.step(move)
+            turn_white = True
+        screen.fill((0, 0, 0))
+        draw_board(screen, env.board, images)
+        pygame.display.flip()
+        if env.board.is_game_over():
+            print("Game over:", env.board.result())
+            running = False
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, required=True)
+    args = parser.parse_args()
+    play(args.model)

--- a/chess_ai/rl_agent.py
+++ b/chess_ai/rl_agent.py
@@ -1,0 +1,32 @@
+import random
+import chess
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+BOARD_SIZE = 64
+
+class PolicyNetwork(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(BOARD_SIZE, 128)
+        self.fc2 = nn.Linear(128, BOARD_SIZE)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = F.relu(self.fc1(x))
+        return self.fc2(x)
+
+def select_move(policy_net: PolicyNetwork, state: np.ndarray, legal_moves):
+    """Return a legal move in UCI format selected by the policy."""
+    with torch.no_grad():
+        logits = policy_net(torch.tensor(state, dtype=torch.float32))
+        probs = F.softmax(logits, dim=0).numpy()
+
+    move_scores = []
+    for move in legal_moves:
+        square = chess.SQUARE_NAMES.index(move[:2])
+        move_scores.append(probs[square])
+    if move_scores:
+        return random.choices(legal_moves, weights=move_scores, k=1)[0]
+    return random.choice(legal_moves)

--- a/chess_ai/train.py
+++ b/chess_ai/train.py
@@ -1,0 +1,65 @@
+import argparse
+import torch
+import torch.optim as optim
+import chess
+import torch.nn.functional as F
+from .chess_env import ChessEnv
+from .rl_agent import PolicyNetwork, select_move
+import plotly.graph_objects as go
+
+
+def self_play_episode(env, policy, optimizer, gamma=0.99):
+    state = env.reset()
+    log_probs = []
+    rewards = []
+    done = False
+    while not done:
+        legal = env.legal_moves
+        move = select_move(policy, state, legal)
+        logits = policy(torch.tensor(state, dtype=torch.float32))
+        move_index = chess.SQUARE_NAMES.index(move[:2])
+        log_prob = F.log_softmax(logits, dim=0)[move_index]
+        state, reward, done = env.step(move)
+        log_probs.append(log_prob)
+        rewards.append(reward)
+    returns = []
+    G = 0.0
+    for r in reversed(rewards):
+        G = r + gamma * G
+        returns.insert(0, G)
+    returns = torch.tensor(returns)
+    if returns.std() != 0:
+        returns = (returns - returns.mean()) / (returns.std() + 1e-5)
+    loss = -torch.stack([lp * G for lp, G in zip(log_probs, returns)]).sum()
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+    return sum(rewards)
+
+
+def train(episodes: int, checkpoint: str, plot_file: str | None = None):
+    env = ChessEnv()
+    policy = PolicyNetwork()
+    optimizer = optim.Adam(policy.parameters(), lr=0.001)
+    rewards = []
+    for ep in range(episodes):
+        ep_reward = self_play_episode(env, policy, optimizer)
+        rewards.append(ep_reward)
+        if (ep + 1) % 50 == 0:
+            torch.save(policy.state_dict(), checkpoint)
+            print(f"Episode {ep+1}: checkpoint saved")
+    torch.save(policy.state_dict(), checkpoint)
+    if plot_file:
+        fig = go.Figure(data=go.Scatter(y=rewards))
+        fig.update_layout(title="Episode Rewards", xaxis_title="Episode", yaxis_title="Return")
+        fig.write_html(plot_file)
+        print(f"Training plot saved to {plot_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--episodes", type=int, default=100)
+    parser.add_argument("--checkpoint", type=str, default="agent.pth")
+    parser.add_argument("--plot", type=str, help="Optional HTML output for training curve")
+    args = parser.parse_args()
+    train(args.episodes, args.checkpoint, args.plot)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy<2
+python-chess==1.999
+torch==2.2.2+cpu --extra-index-url https://download.pytorch.org/whl/cpu
+pygame==2.5.2
+cairosvg==2.7.1
+plotly==5.22.0


### PR DESCRIPTION
## Summary
- support training reward plot generation with plotly
- implement Pygame-based board with animated moves
- provide simple SVG chess piece set
- document graphical interface usage
- pin numpy version for torch compatibility

## Testing
- `pip install -r requirements.txt` *(passes)*
- `python -m chess_ai.train --episodes 1 --checkpoint agent.pth --plot training.html` *(creates plot)*
- `printf 'e2e4\n' | python -m chess_ai.play_ui --model agent.pth` *(fails: EOF when reading a line)*
- `SDL_VIDEODRIVER=dummy python -m chess_ai.pygame_ui --model agent.pth` *(starts then interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685758754d5c83229c61bbad3353f589